### PR TITLE
Remove hardcoded requirements from setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ six >= 1.10
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
 urllib3 >= 1.15.1
+python-dateutil >= 2.6.0

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@
 """
 
 
+impoer os
 import sys
 from setuptools import setup, find_packages
 
@@ -23,7 +24,10 @@ VERSION = "1.0.0"
 # prerequisite: setuptools
 # http://pypi.python.org/pypi/setuptools
 
-REQUIRES = ["urllib3 >= 1.15", "six >= 1.10", "certifi", "python-dateutil"]
+with open('requirements.txt', 'rb') as f:
+    requirements = f.readlines()
+
+REQUIRES = [r.replace(os.linesep, '') for r in requirements]
 
 setup(
     name=NAME,


### PR DESCRIPTION
Keeping requirements lists both in setup.py and requirements.txt is hard
to support. Let's use requirements.txt as a source of trust and load
them to setup.py