### PR TITLE
Remove default Content-Type value from the request header

### DIFF
--- a/openfintech_sdk/api_client.py
+++ b/openfintech_sdk/api_client.py
@@ -479,7 +479,7 @@ class ApiClient(object):
         :return: Content-Type (e.g. application/json).
         """
         if not content_types:
-            return 'application/json'
+            return None
 
         content_types = [x.lower() for x in content_types]
 

--- a/openfintech_sdk/apis/banks_api.py
+++ b/openfintech_sdk/apis/banks_api.py
@@ -148,8 +148,9 @@ class BanksApi(object):
             del header_params['Accept']
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = self.api_client.\
-            select_header_content_type([])
+        content_type = self.api_client.select_header_content_type([])
+        if content_type:
+            header_params['Content-Type'] = content_type
 
         # Authentication setting
         auth_settings = []

--- a/openfintech_sdk/rest.py
+++ b/openfintech_sdk/rest.py
@@ -129,9 +129,6 @@ class RESTClientObject(object):
             elif isinstance(_request_timeout, tuple) and len(_request_timeout) == 2:
                 timeout = urllib3.Timeout(connect=_request_timeout[0], read=_request_timeout[1])
 
-        if 'Content-Type' not in headers:
-            headers['Content-Type'] = 'application/json'
-
         try:
             # For `POST`, `PUT`, `PATCH`, `OPTIONS`, `DELETE`
             if method in ['POST', 'PUT', 'PATCH', 'OPTIONS', 'DELETE']:


### PR DESCRIPTION
According to the documentation there is no need to pass Content-Type
into the request header. With this header client doesn't work with API.

#3 