### PR TITLE
Move HTTP headers initialization to ApiClient

### DIFF
--- a/openfintech_sdk/api_client.py
+++ b/openfintech_sdk/api_client.py
@@ -2,10 +2,75 @@
 """
     OpenFinTech.io API
 
-    # Introduction [OpenFinTech.io](https://openfintech.io) is an open database that comprises of standardized primary data for FinTech industry.<br> It contains such information as geolocation data (countries, cities, regions), organizations, currencies (national, digital, virtual, crypto), banks, digital exchangers, payment providers (PSP), payment methods, etc.<br> It is created for communication of cross-integrated micro-services on \"one language\". This is achieved through standardization of entity identifiers that are used to exchange information among different services.<br>  ### UML UML Domain Model diagram you can find [here](https://s3-eu-west-1.amazonaws.com/uploads-eu.hipchat.com/386820/4572695/rRdwJEYiMkoJrSR/Openfintech%20Design%20Model%20Public.png).<br>  ### Persistence Entities are updated not more than 1 time per day.<br>  ### Terms and Conditions This *OpenFinTech.io* is made available under the [Open Database License](http://opendatacommons.org/licenses/odbl/1.0/).<br> Any rights in individual contents of the database are licensed under the [Database Contents License](http://opendatacommons.org/licenses/dbcl/1.0/).<br>  ### Contacts For any questions, please email - info@openfintech.io     Powered by [Paymaxi](https://www.paymaxi.com)  # Get Started  If you use [POSTMAN](https://www.getpostman.com) or similar program which can operate with swagger`s files - just [download](https://docs.openfintech.io) our spec and [import it](https://www.getpostman.com/docs/importing_swagger). Also you can try live [API demo](https://api.openfintech.io).  ## Overview  The OpenFinTech API is organized around [REST](https://en.wikipedia.org/wiki/Representational_state_transfer). Our API has predictable, resource-oriented URLs, and uses HTTP response codes to indicate API errors.<br> API is based on [JSON API](http://jsonapi.org) standard. JSON is returned by all API responses, including errors, although our API libraries convert responses to appropriate language-specific objects.<br> JSON API requires use of the JSON API media type (`application/vnd.api+json`) for exchanging data.<br> ### Additional Request Headers #### ACCEPT HEADER Your requests should always include the header: ```curl Accept: application/vnd.api+json ```  ## Authentication  To use OpenFinTech API no needed authorization.  ## Versioning  When we make changes to the API, we release new, dated versions. The current version is **2017-01-24**. Read our [API upgrades guide]() to see our API changelog and to learn more about backwards compatibility.  ## Pagination  OpenFinTech APIs to retrieve lists of banks, currencies and other resources - paginated to **100** items by default. The pagination information will be included in the list API response under the node name `meta` - contains information about listed objects [`total` - contains information about total count of listed objects, `pages` - count of pages], `links` - contain links to navigate between pages [`first` - link to first page, `prev` - link to previous page, `next` - link to next page, `last` - link to last page].<br> By default first page will be listed. For navigating through pages, use the page parameter (e.g. `page[number]`, `page[size]`).<br> The `page[size]` parameter can be used to set the number of records that you want to receive in the response.<br> The `page[number]` parameter can be used to set needed page number.<br> Exanple of response: ```json {   \"meta\": {     \"total\": 419,     \"pages\": 42   },   \"links\": {     \"first\": \"/v1/{path}?page[number]=1&page[size]=10\",     \"prev\": \"/v1/{path}?page[number]=39&page[size]=10\",     \"next\": \"/v1/{path}?page[number]=41&page[size]=10\",     \"last\": \"/v1/{path}?page[number]=42&page[size]=10\"   } ```  ### Sorting  OpenFinTech\\`s API supported query parameter to sort result collection [e.g. `?sort=alias`]. Information about available parameters may be found in the endpoint description. Positive parameter [e.g. `?sort=alias`] points to ascending sorting, negative  [e.g. `?sort=-alias`] - to descending sorting. Also, supported multiple sorting parameters [e.g. `?sort=alias, -name, id`, etc.] ```curl https://api.openfintech.io/v1/countries?sort=name,-area ```  ### Filtering  Filtering provided by unique query key `filter[*filtering_condition*]`. Information about available parameters may be found in the endpoint description. ```curl https://api.openfintech.io/v1/countries?filter[region]=europe ```  ## Errors  API uses conventional HTTP response codes to indicate the success or failure of an API request. In general, codes in the `2xx` range indicate success, codes in the `4xx` range indicate an error that failed given the information provided (e.g., a required parameter was omitted, etc.), and codes in the `5xx` range indicate an error with OpenFinTech's servers (these are rare).  | Code | Description | |------|-------------| | 200 - OK | Everything worked as expected. | | 400 - Bad Request | The request was unacceptable, often due to missing a required parameter. | | 401 - Unauthorized | No valid API key provided. | | 402 - Request Failed | The parameters were valid but the request failed. | | 404 - Not Found | The requested resource doesn't exist. | | 409 - Conflict | The request conflicts with another request (perhaps due to using the same idempotent key). | | 429 - Too Many Requests | Too many requests hit the API too quickly. We recommend an exponential backoff of your requests. | | 500, 502, 503, 504 - Server Errors | Something went wrong on OpenFinTech's end. (These are rare.) | 
+    Introduction [OpenFinTech.io](https://openfintech.io) is an open database
+    that comprises of standardized primary data for FinTech industry.
+    It contains such information as geolocation data (countries, cities,
+    regions), organizations, currencies (national, digital, virtual, crypto),
+    banks, digital exchangers, payment providers (PSP), payment methods, etc.
+
+    It is created for communication of cross-integrated micro-services
+    on "one language". This is achieved through standardization of entity
+    identifiers that are used to exchange information among different services.
+
+    UML Domain Model diagram you can find here:
+    https://s3-eu-west-1.amazonaws.com/uploads-eu.hipchat.com/386820/4572695/
+    rRdwJEYiMkoJrSR/Openfintech%20Design%20Model%20Public.png
+
+    Persistence Entities are updated not more than 1 time per day.
+    Terms and Conditions This *OpenFinTech.io* is made available under the
+
+    [Open Database License](http://opendatacommons.org/licenses/odbl/1.0/).
+    Any rights in individual contents of the database are licensed under the
+    [Database Contents License](http://opendatacommons.org/licenses/dbcl/1.0/).
+
+    Contacts For any questions, please email - info@openfintech.io
+
+    Powered by [Paymaxi](https://www.paymaxi.com)
+
+    Get Started  If you use [POSTMAN](https://www.getpostman.com) or similar
+    program which can operate with swagger`s files - just [
+    download](https://docs.openfintech.io) our spec and
+    [import it](https://www.getpostman.com/docs/importing_swagger). Also you
+    can try live [API demo](https://api.openfintech.io).
+    Overview  The OpenFinTech API is organized around
+    [REST](https://en.wikipedia.org/wiki/Representational_state_transfer).
+
+    Our API has predictable, resource-oriented URLs, and uses HTTP response
+    codes to indicate API errors.<br> API is based on
+    [JSON API](http://jsonapi.org) standard. JSON is returned by all API
+    responses, including errors, although our API libraries convert responses
+    to appropriate language-specific objects.<br> JSON API requires use of the
+    JSON API media type (`application/vnd.api+json`) for exchanging data.
+
+    Additional Request Headers
+
+    ACCEPT HEADER Your requests should always include the header:
+    ```curl Accept: application/vnd.api+json ```
+
+    Authentication  To use OpenFinTech API no needed authorization.
+
+    Versioning  When we make changes to the API, we release new, dated
+    versions. The current version is **2017-01-24**. Read our
+    [API upgrades guide]() to see our API changelog and to learn more about
+    backwards compatibility.  ## Pagination  OpenFinTech APIs to retrieve lists
+    of banks, currencies and other resources - paginated to **100** items
+    by default. The pagination information will be included in the list API
+    response under the node name `meta` - contains information about listed
+    objects [`total` - contains information about total count of listed
+    objects, `pages` - count of pages], `links` - contain links to navigate
+    between pages [`first` - link to first page, `prev` - link to previous
+    page, `next` - link to next page, `last` - link to last page].
+
+    By default first page will be listed. For navigating through pages, use the
+    page parameter (e.g. `page[number]`, `page[size]`).<br> The `page[size]`
+    parameter can be used to set the number of records that you want to receive
+    in the response.<br> The `page[number]` parameter can be used to set needed
+    page number.<br> Exanple of response:
+    ```json {   \"meta\": {     \"total\": 419,     \"pages\": 42   },
+    \"links\": {     \"first\": \"/v1/{path}?page[number]=1&page[size]=10\",     \"prev\": \"/v1/{path}?page[number]=39&page[size]=10\",     \"next\": \"/v1/{path}?page[number]=41&page[size]=10\",     \"last\": \"/v1/{path}?page[number]=42&page[size]=10\"   } ```  ### Sorting  OpenFinTech\\`s API supported query parameter to sort result collection [e.g. `?sort=alias`]. Information about available parameters may be found in the endpoint description. Positive parameter [e.g. `?sort=alias`] points to ascending sorting, negative  [e.g. `?sort=-alias`] - to descending sorting. Also, supported multiple sorting parameters [e.g. `?sort=alias, -name, id`, etc.] ```curl https://api.openfintech.io/v1/countries?sort=name,-area ```  ### Filtering  Filtering provided by unique query key `filter[*filtering_condition*]`. Information about available parameters may be found in the endpoint description. ```curl https://api.openfintech.io/v1/countries?filter[region]=europe ```  ## Errors  API uses conventional HTTP response codes to indicate the success or failure of an API request. In general, codes in the `2xx` range indicate success, codes in the `4xx` range indicate an error that failed given the information provided (e.g., a required parameter was omitted, etc.), and codes in the `5xx` range indicate an error with OpenFinTech's servers (these are rare).  | Code | Description | |------|-------------| | 200 - OK | Everything worked as expected. | | 400 - Bad Request | The request was unacceptable, often due to missing a required parameter. | | 401 - Unauthorized | No valid API key provided. | | 402 - Request Failed | The parameters were valid but the request failed. | | 404 - Not Found | The requested resource doesn't exist. | | 409 - Conflict | The request conflicts with another request (perhaps due to using the same idempotent key). | | 429 - Too Many Requests | Too many requests hit the API too quickly. We recommend an exponential backoff of your requests. | | 500, 502, 503, 504 - Server Errors | Something went wrong on OpenFinTech's end. (These are rare.) | 
 
     OpenAPI spec version: 2017-01-24
-    
+
     Generated by: https://github.com/swagger-api/swagger-codegen.git
 """
 
@@ -100,7 +165,19 @@ class ApiClient(object):
                    _request_timeout=None):
 
         # header parameters
-        header_params = header_params or {}
+        if not header_params:
+            # HTTP header `Accept`
+            header_params = {}
+            header_params['Accept'] = self.select_header_accept(['application/vnd.api+json'])
+            if not header_params['Accept']:
+                del header_params['Accept']
+
+            # HTTP header `Content-Type`
+            content_type = self.select_header_content_type([])
+            if content_type:
+                header_params['Content-Type'] = content_type
+        else:
+            header_params = header_params
         header_params.update(self.default_headers)
         if self.cookie:
             header_params['Cookie'] = self.cookie
@@ -556,6 +633,9 @@ class ApiClient(object):
             return unicode(data)
         except TypeError:
             return data
+        except Exception:
+            # TODO(e0ne) add logging
+            return unicode(data)
 
     def __deserialize_object(self, value):
         """

--- a/openfintech_sdk/apis/banks_api.py
+++ b/openfintech_sdk/apis/banks_api.py
@@ -134,23 +134,10 @@ class BanksApi(object):
             query_params['sort'] = params['sort']
             collection_formats['sort'] = 'csv'
 
-        header_params = {}
-
         form_params = []
         local_var_files = {}
 
         body_params = None
-
-        # HTTP header `Accept`
-        header_params['Accept'] = self.api_client.\
-            select_header_accept(['application/vnd.api+json'])
-        if not header_params['Accept']:
-            del header_params['Accept']
-
-        # HTTP header `Content-Type`
-        content_type = self.api_client.select_header_content_type([])
-        if content_type:
-            header_params['Content-Type'] = content_type
 
         # Authentication setting
         auth_settings = []
@@ -158,7 +145,6 @@ class BanksApi(object):
         return self.api_client.call_api(resource_path, 'GET',
                                         path_params,
                                         query_params,
-                                        header_params,
                                         body=body_params,
                                         post_params=form_params,
                                         files=local_var_files,
@@ -235,7 +221,6 @@ class BanksApi(object):
         if ('id' not in params) or (params['id'] is None):
             raise ValueError("Missing the required parameter `id` when calling `banks_id_get`")
 
-
         collection_formats = {}
 
         resource_path = '/banks/{id}'.replace('{format}', 'json')
@@ -245,22 +230,10 @@ class BanksApi(object):
 
         query_params = {}
 
-        header_params = {}
-
         form_params = []
         local_var_files = {}
 
         body_params = None
-
-        # HTTP header `Accept`
-        header_params['Accept'] = self.api_client.\
-            select_header_accept(['application/vnd.api+json'])
-        if not header_params['Accept']:
-            del header_params['Accept']
-
-        # HTTP header `Content-Type`
-        header_params['Content-Type'] = self.api_client.\
-            select_header_content_type([])
 
         # Authentication setting
         auth_settings = []
@@ -268,7 +241,6 @@ class BanksApi(object):
         return self.api_client.call_api(resource_path, 'GET',
                                         path_params,
                                         query_params,
-                                        header_params,
                                         body=body_params,
                                         post_params=form_params,
                                         files=local_var_files,

--- a/openfintech_sdk/apis/countries_api.py
+++ b/openfintech_sdk/apis/countries_api.py
@@ -131,22 +131,10 @@ class CountriesApi(object):
             query_params['sort'] = params['sort']
             collection_formats['sort'] = 'csv'
 
-        header_params = {}
-
         form_params = []
         local_var_files = {}
 
         body_params = None
-
-        # HTTP header `Accept`
-        header_params['Accept'] = self.api_client.\
-            select_header_accept(['application/vnd.api+json'])
-        if not header_params['Accept']:
-            del header_params['Accept']
-
-        # HTTP header `Content-Type`
-        header_params['Content-Type'] = self.api_client.\
-            select_header_content_type([])
 
         # Authentication setting
         auth_settings = []
@@ -154,7 +142,6 @@ class CountriesApi(object):
         return self.api_client.call_api(resource_path, 'GET',
                                         path_params,
                                         query_params,
-                                        header_params,
                                         body=body_params,
                                         post_params=form_params,
                                         files=local_var_files,
@@ -241,22 +228,10 @@ class CountriesApi(object):
 
         query_params = {}
 
-        header_params = {}
-
         form_params = []
         local_var_files = {}
 
         body_params = None
-
-        # HTTP header `Accept`
-        header_params['Accept'] = self.api_client.\
-            select_header_accept(['application/vnd.api+json'])
-        if not header_params['Accept']:
-            del header_params['Accept']
-
-        # HTTP header `Content-Type`
-        header_params['Content-Type'] = self.api_client.\
-            select_header_content_type([])
 
         # Authentication setting
         auth_settings = []
@@ -264,7 +239,6 @@ class CountriesApi(object):
         return self.api_client.call_api(resource_path, 'GET',
                                         path_params,
                                         query_params,
-                                        header_params,
                                         body=body_params,
                                         post_params=form_params,
                                         files=local_var_files,

--- a/openfintech_sdk/apis/currencies_api.py
+++ b/openfintech_sdk/apis/currencies_api.py
@@ -143,22 +143,10 @@ class CurrenciesApi(object):
             query_params['sort'] = params['sort']
             collection_formats['sort'] = 'csv'
 
-        header_params = {}
-
         form_params = []
         local_var_files = {}
 
         body_params = None
-
-        # HTTP header `Accept`
-        header_params['Accept'] = self.api_client.\
-            select_header_accept(['application/vnd.api+json'])
-        if not header_params['Accept']:
-            del header_params['Accept']
-
-        # HTTP header `Content-Type`
-        header_params['Content-Type'] = self.api_client.\
-            select_header_content_type([])
 
         # Authentication setting
         auth_settings = []
@@ -166,7 +154,6 @@ class CurrenciesApi(object):
         return self.api_client.call_api(resource_path, 'GET',
                                         path_params,
                                         query_params,
-                                        header_params,
                                         body=body_params,
                                         post_params=form_params,
                                         files=local_var_files,
@@ -253,22 +240,10 @@ class CurrenciesApi(object):
 
         query_params = {}
 
-        header_params = {}
-
         form_params = []
         local_var_files = {}
 
         body_params = None
-
-        # HTTP header `Accept`
-        header_params['Accept'] = self.api_client.\
-            select_header_accept(['application/vnd.api+json'])
-        if not header_params['Accept']:
-            del header_params['Accept']
-
-        # HTTP header `Content-Type`
-        header_params['Content-Type'] = self.api_client.\
-            select_header_content_type([])
 
         # Authentication setting
         auth_settings = []
@@ -276,7 +251,6 @@ class CurrenciesApi(object):
         return self.api_client.call_api(resource_path, 'GET',
                                         path_params,
                                         query_params,
-                                        header_params,
                                         body=body_params,
                                         post_params=form_params,
                                         files=local_var_files,

--- a/openfintech_sdk/apis/exchangers_api.py
+++ b/openfintech_sdk/apis/exchangers_api.py
@@ -130,22 +130,10 @@ class ExchangersApi(object):
             query_params['sort'] = params['sort']
             collection_formats['sort'] = 'csv'
 
-        header_params = {}
-
         form_params = []
         local_var_files = {}
 
         body_params = None
-
-        # HTTP header `Accept`
-        header_params['Accept'] = self.api_client.\
-            select_header_accept(['application/vnd.api+json'])
-        if not header_params['Accept']:
-            del header_params['Accept']
-
-        # HTTP header `Content-Type`
-        header_params['Content-Type'] = self.api_client.\
-            select_header_content_type([])
 
         # Authentication setting
         auth_settings = []
@@ -153,7 +141,6 @@ class ExchangersApi(object):
         return self.api_client.call_api(resource_path, 'GET',
                                         path_params,
                                         query_params,
-                                        header_params,
                                         body=body_params,
                                         post_params=form_params,
                                         files=local_var_files,
@@ -230,7 +217,6 @@ class ExchangersApi(object):
         if ('id' not in params) or (params['id'] is None):
             raise ValueError("Missing the required parameter `id` when calling `exchangers_id_get`")
 
-
         collection_formats = {}
 
         resource_path = '/exchangers/{id}'.replace('{format}', 'json')
@@ -240,22 +226,10 @@ class ExchangersApi(object):
 
         query_params = {}
 
-        header_params = {}
-
         form_params = []
         local_var_files = {}
 
         body_params = None
-
-        # HTTP header `Accept`
-        header_params['Accept'] = self.api_client.\
-            select_header_accept(['application/vnd.api+json'])
-        if not header_params['Accept']:
-            del header_params['Accept']
-
-        # HTTP header `Content-Type`
-        header_params['Content-Type'] = self.api_client.\
-            select_header_content_type([])
 
         # Authentication setting
         auth_settings = []
@@ -263,7 +237,6 @@ class ExchangersApi(object):
         return self.api_client.call_api(resource_path, 'GET',
                                         path_params,
                                         query_params,
-                                        header_params,
                                         body=body_params,
                                         post_params=form_params,
                                         files=local_var_files,

--- a/openfintech_sdk/apis/industries_api.py
+++ b/openfintech_sdk/apis/industries_api.py
@@ -116,22 +116,10 @@ class IndustriesApi(object):
         if 'page_size' in params:
             query_params['page[size]'] = params['page_size']
 
-        header_params = {}
-
         form_params = []
         local_var_files = {}
 
         body_params = None
-
-        # HTTP header `Accept`
-        header_params['Accept'] = self.api_client.\
-            select_header_accept(['application/vnd.api+json'])
-        if not header_params['Accept']:
-            del header_params['Accept']
-
-        # HTTP header `Content-Type`
-        header_params['Content-Type'] = self.api_client.\
-            select_header_content_type([])
 
         # Authentication setting
         auth_settings = []
@@ -139,7 +127,6 @@ class IndustriesApi(object):
         return self.api_client.call_api(resource_path, 'GET',
                                         path_params,
                                         query_params,
-                                        header_params,
                                         body=body_params,
                                         post_params=form_params,
                                         files=local_var_files,
@@ -226,22 +213,10 @@ class IndustriesApi(object):
 
         query_params = {}
 
-        header_params = {}
-
         form_params = []
         local_var_files = {}
 
         body_params = None
-
-        # HTTP header `Accept`
-        header_params['Accept'] = self.api_client.\
-            select_header_accept(['application/vnd.api+json'])
-        if not header_params['Accept']:
-            del header_params['Accept']
-
-        # HTTP header `Content-Type`
-        header_params['Content-Type'] = self.api_client.\
-            select_header_content_type([])
 
         # Authentication setting
         auth_settings = []
@@ -249,7 +224,6 @@ class IndustriesApi(object):
         return self.api_client.call_api(resource_path, 'GET',
                                         path_params,
                                         query_params,
-                                        header_params,
                                         body=body_params,
                                         post_params=form_params,
                                         files=local_var_files,

--- a/openfintech_sdk/apis/issuers_api.py
+++ b/openfintech_sdk/apis/issuers_api.py
@@ -116,22 +116,10 @@ class IssuersApi(object):
         if 'page_size' in params:
             query_params['page[size]'] = params['page_size']
 
-        header_params = {}
-
         form_params = []
         local_var_files = {}
 
         body_params = None
-
-        # HTTP header `Accept`
-        header_params['Accept'] = self.api_client.\
-            select_header_accept(['application/vnd.api+json'])
-        if not header_params['Accept']:
-            del header_params['Accept']
-
-        # HTTP header `Content-Type`
-        header_params['Content-Type'] = self.api_client.\
-            select_header_content_type([])
 
         # Authentication setting
         auth_settings = []
@@ -139,7 +127,6 @@ class IssuersApi(object):
         return self.api_client.call_api(resource_path, 'GET',
                                         path_params,
                                         query_params,
-                                        header_params,
                                         body=body_params,
                                         post_params=form_params,
                                         files=local_var_files,
@@ -226,22 +213,10 @@ class IssuersApi(object):
 
         query_params = {}
 
-        header_params = {}
-
         form_params = []
         local_var_files = {}
 
         body_params = None
-
-        # HTTP header `Accept`
-        header_params['Accept'] = self.api_client.\
-            select_header_accept(['application/vnd.api+json'])
-        if not header_params['Accept']:
-            del header_params['Accept']
-
-        # HTTP header `Content-Type`
-        header_params['Content-Type'] = self.api_client.\
-            select_header_content_type([])
 
         # Authentication setting
         auth_settings = []
@@ -249,7 +224,6 @@ class IssuersApi(object):
         return self.api_client.call_api(resource_path, 'GET',
                                         path_params,
                                         query_params,
-                                        header_params,
                                         body=body_params,
                                         post_params=form_params,
                                         files=local_var_files,

--- a/openfintech_sdk/apis/merchant_industries_api.py
+++ b/openfintech_sdk/apis/merchant_industries_api.py
@@ -120,22 +120,10 @@ class MerchantIndustriesApi(object):
         if 'filter_name' in params:
             query_params['filter[name]'] = params['filter_name']
 
-        header_params = {}
-
         form_params = []
         local_var_files = {}
 
         body_params = None
-
-        # HTTP header `Accept`
-        header_params['Accept'] = self.api_client.\
-            select_header_accept(['application/vnd.api+json'])
-        if not header_params['Accept']:
-            del header_params['Accept']
-
-        # HTTP header `Content-Type`
-        header_params['Content-Type'] = self.api_client.\
-            select_header_content_type([])
 
         # Authentication setting
         auth_settings = []
@@ -143,7 +131,6 @@ class MerchantIndustriesApi(object):
         return self.api_client.call_api(resource_path, 'GET',
                                         path_params,
                                         query_params,
-                                        header_params,
                                         body=body_params,
                                         post_params=form_params,
                                         files=local_var_files,
@@ -230,22 +217,10 @@ class MerchantIndustriesApi(object):
 
         query_params = {}
 
-        header_params = {}
-
         form_params = []
         local_var_files = {}
 
         body_params = None
-
-        # HTTP header `Accept`
-        header_params['Accept'] = self.api_client.\
-            select_header_accept(['application/vnd.api+json'])
-        if not header_params['Accept']:
-            del header_params['Accept']
-
-        # HTTP header `Content-Type`
-        header_params['Content-Type'] = self.api_client.\
-            select_header_content_type([])
 
         # Authentication setting
         auth_settings = []
@@ -253,7 +228,6 @@ class MerchantIndustriesApi(object):
         return self.api_client.call_api(resource_path, 'GET',
                                         path_params,
                                         query_params,
-                                        header_params,
                                         body=body_params,
                                         post_params=form_params,
                                         files=local_var_files,

--- a/openfintech_sdk/apis/organizations_api.py
+++ b/openfintech_sdk/apis/organizations_api.py
@@ -138,22 +138,10 @@ class OrganizationsApi(object):
             query_params['sort'] = params['sort']
             collection_formats['sort'] = 'csv'
 
-        header_params = {}
-
         form_params = []
         local_var_files = {}
 
         body_params = None
-
-        # HTTP header `Accept`
-        header_params['Accept'] = self.api_client.\
-            select_header_accept(['application/vnd.api+json'])
-        if not header_params['Accept']:
-            del header_params['Accept']
-
-        # HTTP header `Content-Type`
-        header_params['Content-Type'] = self.api_client.\
-            select_header_content_type([])
 
         # Authentication setting
         auth_settings = []
@@ -161,7 +149,6 @@ class OrganizationsApi(object):
         return self.api_client.call_api(resource_path, 'GET',
                                         path_params,
                                         query_params,
-                                        header_params,
                                         body=body_params,
                                         post_params=form_params,
                                         files=local_var_files,
@@ -248,22 +235,10 @@ class OrganizationsApi(object):
 
         query_params = {}
 
-        header_params = {}
-
         form_params = []
         local_var_files = {}
 
         body_params = None
-
-        # HTTP header `Accept`
-        header_params['Accept'] = self.api_client.\
-            select_header_accept(['application/vnd.api+json'])
-        if not header_params['Accept']:
-            del header_params['Accept']
-
-        # HTTP header `Content-Type`
-        header_params['Content-Type'] = self.api_client.\
-            select_header_content_type([])
 
         # Authentication setting
         auth_settings = []
@@ -271,7 +246,6 @@ class OrganizationsApi(object):
         return self.api_client.call_api(resource_path, 'GET',
                                         path_params,
                                         query_params,
-                                        header_params,
                                         body=body_params,
                                         post_params=form_params,
                                         files=local_var_files,

--- a/openfintech_sdk/apis/payment_methods_api.py
+++ b/openfintech_sdk/apis/payment_methods_api.py
@@ -138,22 +138,10 @@ class PaymentMethodsApi(object):
             query_params['sort'] = params['sort']
             collection_formats['sort'] = 'csv'
 
-        header_params = {}
-
         form_params = []
         local_var_files = {}
 
         body_params = None
-
-        # HTTP header `Accept`
-        header_params['Accept'] = self.api_client.\
-            select_header_accept(['application/vnd.api+json'])
-        if not header_params['Accept']:
-            del header_params['Accept']
-
-        # HTTP header `Content-Type`
-        header_params['Content-Type'] = self.api_client.\
-            select_header_content_type([])
 
         # Authentication setting
         auth_settings = []
@@ -161,7 +149,6 @@ class PaymentMethodsApi(object):
         return self.api_client.call_api(resource_path, 'GET',
                                         path_params,
                                         query_params,
-                                        header_params,
                                         body=body_params,
                                         post_params=form_params,
                                         files=local_var_files,
@@ -248,22 +235,10 @@ class PaymentMethodsApi(object):
 
         query_params = {}
 
-        header_params = {}
-
         form_params = []
         local_var_files = {}
 
         body_params = None
-
-        # HTTP header `Accept`
-        header_params['Accept'] = self.api_client.\
-            select_header_accept(['application/vnd.api+json'])
-        if not header_params['Accept']:
-            del header_params['Accept']
-
-        # HTTP header `Content-Type`
-        header_params['Content-Type'] = self.api_client.\
-            select_header_content_type([])
 
         # Authentication setting
         auth_settings = []
@@ -271,7 +246,6 @@ class PaymentMethodsApi(object):
         return self.api_client.call_api(resource_path, 'GET',
                                         path_params,
                                         query_params,
-                                        header_params,
                                         body=body_params,
                                         post_params=form_params,
                                         files=local_var_files,

--- a/openfintech_sdk/apis/payment_processors_api.py
+++ b/openfintech_sdk/apis/payment_processors_api.py
@@ -120,22 +120,11 @@ class PaymentProcessorsApi(object):
         if 'filter_name' in params:
             query_params['filter[name]'] = params['filter_name']
 
-        header_params = {}
 
         form_params = []
         local_var_files = {}
 
         body_params = None
-
-        # HTTP header `Accept`
-        header_params['Accept'] = self.api_client.\
-            select_header_accept(['application/vnd.api+json'])
-        if not header_params['Accept']:
-            del header_params['Accept']
-
-        # HTTP header `Content-Type`
-        header_params['Content-Type'] = self.api_client.\
-            select_header_content_type([])
 
         # Authentication setting
         auth_settings = []
@@ -143,7 +132,6 @@ class PaymentProcessorsApi(object):
         return self.api_client.call_api(resource_path, 'GET',
                                         path_params,
                                         query_params,
-                                        header_params,
                                         body=body_params,
                                         post_params=form_params,
                                         files=local_var_files,
@@ -230,22 +218,10 @@ class PaymentProcessorsApi(object):
 
         query_params = {}
 
-        header_params = {}
-
         form_params = []
         local_var_files = {}
 
         body_params = None
-
-        # HTTP header `Accept`
-        header_params['Accept'] = self.api_client.\
-            select_header_accept(['application/vnd.api+json'])
-        if not header_params['Accept']:
-            del header_params['Accept']
-
-        # HTTP header `Content-Type`
-        header_params['Content-Type'] = self.api_client.\
-            select_header_content_type([])
 
         # Authentication setting
         auth_settings = []
@@ -253,7 +229,6 @@ class PaymentProcessorsApi(object):
         return self.api_client.call_api(resource_path, 'GET',
                                         path_params,
                                         query_params,
-                                        header_params,
                                         body=body_params,
                                         post_params=form_params,
                                         files=local_var_files,

--- a/openfintech_sdk/apis/payment_providers_api.py
+++ b/openfintech_sdk/apis/payment_providers_api.py
@@ -144,22 +144,10 @@ class PaymentProvidersApi(object):
             query_params['sort'] = params['sort']
             collection_formats['sort'] = 'csv'
 
-        header_params = {}
-
         form_params = []
         local_var_files = {}
 
         body_params = None
-
-        # HTTP header `Accept`
-        header_params['Accept'] = self.api_client.\
-            select_header_accept(['application/vnd.api+json'])
-        if not header_params['Accept']:
-            del header_params['Accept']
-
-        # HTTP header `Content-Type`
-        header_params['Content-Type'] = self.api_client.\
-            select_header_content_type([])
 
         # Authentication setting
         auth_settings = []
@@ -167,7 +155,6 @@ class PaymentProvidersApi(object):
         return self.api_client.call_api(resource_path, 'GET',
                                         path_params,
                                         query_params,
-                                        header_params,
                                         body=body_params,
                                         post_params=form_params,
                                         files=local_var_files,
@@ -254,22 +241,10 @@ class PaymentProvidersApi(object):
 
         query_params = {}
 
-        header_params = {}
-
         form_params = []
         local_var_files = {}
 
         body_params = None
-
-        # HTTP header `Accept`
-        header_params['Accept'] = self.api_client.\
-            select_header_accept(['application/vnd.api+json'])
-        if not header_params['Accept']:
-            del header_params['Accept']
-
-        # HTTP header `Content-Type`
-        header_params['Content-Type'] = self.api_client.\
-            select_header_content_type([])
 
         # Authentication setting
         auth_settings = []
@@ -277,7 +252,6 @@ class PaymentProvidersApi(object):
         return self.api_client.call_api(resource_path, 'GET',
                                         path_params,
                                         query_params,
-                                        header_params,
                                         body=body_params,
                                         post_params=form_params,
                                         files=local_var_files,


### PR DESCRIPTION
We need the same headers for all resource APIs. This patch moves HTTP
headers initialization to ApiClient and fixes these clients.

Also, some initial cleanup for ApiClient docsting was done.